### PR TITLE
Correct note about not being able to use subtype's method

### DIFF
--- a/_posts/2020-08-24-resist-the-any-type.markdown
+++ b/_posts/2020-08-24-resist-the-any-type.markdown
@@ -192,7 +192,7 @@ sort_animals_by_name(not_animals)
 ```
 
 Because we specified that `AnimalType` must be a subtype of `Animal`, the type-checker allows us to use the `name` property from `Animal` within our function.
-Note that we still aren't able to use a more specific method like `pat` within the body of the `sort_animals_by_name`, since it doesn't always exist on that upper bound, `Animal`.
+Note that we still aren't able to use a more specific method like `pat` within the body of `sort_animals_by_name`, since it doesn't always exist on that upper bound, `Animal`.
 
 ### Misconceptions about scoping
 

--- a/_posts/2020-08-24-resist-the-any-type.markdown
+++ b/_posts/2020-08-24-resist-the-any-type.markdown
@@ -192,7 +192,7 @@ sort_animals_by_name(not_animals)
 ```
 
 Because we specified that `AnimalType` must be a subtype of `Animal`, the type-checker allows us to use the `name` property from `Animal` within our function.
-Note that we still aren't able to use a more specific method like `pat`, since it doesn't always exist on that upper bound, `Animal`.
+Note that we are still able to use the method `pat` because it is exists in our given subtype (`Dog`), even though it doesn't always exist on the upper bound `Animal`.
 
 ### Misconceptions about scoping
 

--- a/_posts/2020-08-24-resist-the-any-type.markdown
+++ b/_posts/2020-08-24-resist-the-any-type.markdown
@@ -192,7 +192,7 @@ sort_animals_by_name(not_animals)
 ```
 
 Because we specified that `AnimalType` must be a subtype of `Animal`, the type-checker allows us to use the `name` property from `Animal` within our function.
-Note that we are still able to use the method `pat` because it is exists in our given subtype (`Dog`), even though it doesn't always exist on the upper bound `Animal`.
+Note that we still aren't able to use a more specific method like `pat` within the body of the `sort_animals_by_name`, since it doesn't always exist on that upper bound, `Animal`.
 
 ### Misconceptions about scoping
 

--- a/_posts/2020-08-24-resist-the-any-type.markdown
+++ b/_posts/2020-08-24-resist-the-any-type.markdown
@@ -192,7 +192,7 @@ sort_animals_by_name(not_animals)
 ```
 
 Because we specified that `AnimalType` must be a subtype of `Animal`, the type-checker allows us to use the `name` property from `Animal` within our function.
-Note that we still aren't able to use a more specific method like `pat` within the body of `sort_animals_by_name`, since it doesn't always exist on that upper bound, `Animal`.
+Note that we still aren't able to use a more specific method like `pat` within the body of `sort_animals_by_name`, since it doesn't always exist on the upper bound, `Animal`.
 
 ### Misconceptions about scoping
 


### PR DESCRIPTION
Hi Jared,

Great post, thanks!

I'm just suggesting a fix, as I think this part might not be right. If I make a Python file `t.py` with
```python
from typing import List, TypeVar
from dataclasses import dataclass

@dataclass
class Animal:
    name: str


class Dog(Animal):
    def pat(self) -> None:
        print(f"gave {self.name} a good pat")


class Cat(Animal):
    def stroke(self) -> None:
        print(f"stroked {self.name}")


AnimalType = TypeVar('AnimalType', bound=Animal)


def sort_animals_by_name(items: List[AnimalType]) -> List[AnimalType]:
    return sorted(items, key=lambda animal: animal.name)


# This is valid (all the inputs are dogs so all have the 'pat' method)
sorted_dogs = sort_animals_by_name([Dog(name="spots"), Dog(name="buzz")])
sorted_dogs[0].pat()
```
then `mypy` doesn't find any errors:
```console
$ mypy t.py 
Success: no issues found in 1 source file
```

In fact, my understanding is that if you use [`TypeVar` with an upper bound](https://mypy.readthedocs.io/en/stable/generics.html#type-variables-with-upper-bounds), then you can still access the subtype's properties. If, however, you had used [typevar with value restriction](https://mypy.readthedocs.io/en/stable/generics.html#type-variable-value-restriction), then that wouldn't have been possible.

Indeed, if I add
```python
reveal_type(sorted_dogs[0])
```
to the end of `t.py`, then I get
```console
$ mypy t.py 
t.py:29: note: Revealed type is 't.Dog*'
```